### PR TITLE
supply 'use_zend_loader' => false

### DIFF
--- a/config/application.config.php
+++ b/config/application.config.php
@@ -3,11 +3,7 @@
 return [
     'modules' => require __DIR__ . '/modules.config.php',
     'module_listener_options' => [
-        'module_paths' => [
-            './module',
-            './vendor',
-            'PhpBenchmarksZendFramework\\HelloWorldModule' => './vendor/phpbenchmarks/zend-framework/src'
-        ],
+        'use_zend_loader' => false,
         'config_glob_paths' => [
             realpath(__DIR__) . '/autoload/{{,*.}global,{,*.}local}.php',
         ],


### PR DESCRIPTION
if `./vendor/phpbenchmarks/zend-framework/src` loaded by composer, it should be enough with ` 'use_zend_loader' => false` config, refs https://zendframework.github.io/zend-modulemanager/module-autoloader/#disabling-the-moduleautoloader